### PR TITLE
Loading Screen fix

### DIFF
--- a/src/components/LoadingScreen/LoadingScreen.module.css
+++ b/src/components/LoadingScreen/LoadingScreen.module.css
@@ -1,3 +1,9 @@
+
+.loading_screen{
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
 .spinner {
     width: 100px;
     height: 100px;

--- a/src/components/LoadingScreen/LoadingScreen.module.css
+++ b/src/components/LoadingScreen/LoadingScreen.module.css
@@ -1,4 +1,3 @@
-
 .loading_screen{
     display: flex;
     flex-wrap: wrap;

--- a/src/components/LoadingScreen/LoadingScreen.module.css
+++ b/src/components/LoadingScreen/LoadingScreen.module.css
@@ -1,13 +1,3 @@
-.loading_screen {
-    overflow: hidden;
-    scrollbar-width: none; /* Для Firefox */
-    -ms-overflow-style: none; /* Для Edge и IE */
-}
-
-.loading_screen::-webkit-scrollbar {
-    display: none; /* Для Chrome, Safari и Opera */
-}
-
 .spinner {
     width: 100px;
     height: 100px;

--- a/src/components/LoadingScreen/LoadingScreen.module.css
+++ b/src/components/LoadingScreen/LoadingScreen.module.css
@@ -1,0 +1,16 @@
+.loading_screen {
+    overflow: hidden;
+    scrollbar-width: none; /* Для Firefox */
+    -ms-overflow-style: none; /* Для Edge и IE */
+}
+
+.loading_screen::-webkit-scrollbar {
+    display: none; /* Для Chrome, Safari и Opera */
+}
+
+.spinner {
+    width: 100px;
+    height: 100px;
+    color: #1a1a1a;
+    margin-top: -5px;
+}

--- a/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/LoadingScreen/LoadingScreen.tsx
@@ -1,6 +1,5 @@
 import React, {FC, useEffect, useState} from "react";
 import { Spinner } from "reactstrap";
-import {inspect} from "util";
 import styles from './LoadingScreen.module.css'
 
 interface LoadingScreenI {

--- a/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/LoadingScreen/LoadingScreen.tsx
@@ -7,14 +7,7 @@ interface LoadingScreenI {
 }
 
 export const LoadingScreen: FC<LoadingScreenI> = ({ isLoading }) => {
-    const [mounted, setMounted] = useState(true);
     const [spinnerCount, setSpinnerCount] = useState(165);
-
-    useEffect(() => {
-        return () => {
-            setMounted(false);
-        };
-    }, []);
 
     useEffect(() => {
         const updateSpinnerCount = () => {

--- a/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/LoadingScreen/LoadingScreen.tsx
@@ -1,15 +1,30 @@
-import React from "react";
+import React, {FC, useEffect} from "react";
 import { Spinner } from "reactstrap";
+import {inspect} from "util";
+import styles from './LoadingScreen.module.css'
 
-export const LoadingScreen = () => {
-  return (
-    <div style={{ margin: 10 }}>
-      {[...Array(100)].map((_,index) => (
-        <Spinner key={index}
-          type="grow"
-          style={{ width: 100, height: 100, color: "#1a1a1a", marginTop: -5 }}
-        />
-      ))}
-    </div>
-  );
+interface LoadingScreenI {
+    isLoading: boolean;
+}
+
+export const LoadingScreen: FC<LoadingScreenI> = ({ isLoading }) => {
+
+    useEffect(() => {
+        if (!isLoading) {
+            document.body.style.overflow = "hidden";
+        } else {
+            document.body.style.overflow = "auto";
+        }
+    }, [isLoading]);
+
+    return (
+        <div className={styles.loading_screen}>
+            {[...Array(5000)].map((_,index) => (
+                <Spinner key={index}
+                         type="grow"
+                         className={styles.spinner}
+                />
+            ))}
+        </div>
+    );
 };

--- a/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/LoadingScreen/LoadingScreen.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useEffect} from "react";
+import React, {FC, useEffect, useState} from "react";
 import { Spinner } from "reactstrap";
 import {inspect} from "util";
 import styles from './LoadingScreen.module.css'
@@ -8,14 +8,21 @@ interface LoadingScreenI {
 }
 
 export const LoadingScreen: FC<LoadingScreenI> = ({ isLoading }) => {
+    const [mounted, setMounted] = useState(true);
 
     useEffect(() => {
-        if (!isLoading) {
+        return () => {
+            setMounted(false);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (isLoading && mounted) {
             document.body.style.overflow = "hidden";
         } else {
             document.body.style.overflow = "auto";
         }
-    }, [isLoading]);
+    }, [isLoading, mounted]);
 
     return (
         <div className={styles.loading_screen}>

--- a/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/LoadingScreen/LoadingScreen.tsx
@@ -26,7 +26,7 @@ export const LoadingScreen: FC<LoadingScreenI> = ({ isLoading }) => {
 
     return (
         <div className={styles.loading_screen}>
-            {[...Array(5000)].map((_,index) => (
+            {[...Array(500)].map((_,index) => (
                 <Spinner key={index}
                          type="grow"
                          className={styles.spinner}

--- a/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/LoadingScreen/LoadingScreen.tsx
@@ -25,7 +25,7 @@ export const LoadingScreen: FC<LoadingScreenI> = ({ isLoading }) => {
 
     return (
         <div className={styles.loading_screen}>
-            {[...Array(500)].map((_,index) => (
+            {[...Array(165)].map((_,index) => (
                 <Spinner key={index}
                          type="grow"
                          className={styles.spinner}

--- a/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/LoadingScreen/LoadingScreen.tsx
@@ -1,6 +1,6 @@
-import React, {FC, useEffect, useState} from "react";
+import React, { FC, useEffect, useState } from "react";
 import { Spinner } from "reactstrap";
-import styles from './LoadingScreen.module.css'
+import styles from "./LoadingScreen.module.css";
 
 interface LoadingScreenI {
     isLoading: boolean;
@@ -8,6 +8,7 @@ interface LoadingScreenI {
 
 export const LoadingScreen: FC<LoadingScreenI> = ({ isLoading }) => {
     const [mounted, setMounted] = useState(true);
+    const [spinnerCount, setSpinnerCount] = useState(165);
 
     useEffect(() => {
         return () => {
@@ -16,21 +17,49 @@ export const LoadingScreen: FC<LoadingScreenI> = ({ isLoading }) => {
     }, []);
 
     useEffect(() => {
-        if (isLoading && mounted) {
-            document.body.style.overflow = "hidden";
-        } else {
+        const updateSpinnerCount = () => {
+            const width = window.innerWidth;
+            const height = window.innerHeight;
+            const spinnersPerRow = Math.ceil(width / 100);
+            const numberOfRows = Math.ceil(height / 100);
+            setSpinnerCount(spinnersPerRow * numberOfRows);
+        };
+
+        window.addEventListener("resize", updateSpinnerCount);
+        updateSpinnerCount();
+
+        return () => {
+            window.removeEventListener("resize", updateSpinnerCount);
+        };
+    }, []);
+
+    useEffect(() => {
+        const handleClassChange = () => {
+            if (isLoading) {
+                document.body.classList.add("no-scrollbar");
+                document.body.style.overflow = "hidden";
+            } else {
+                document.body.classList.remove("no-scrollbar");
+                document.body.style.overflow = "auto";
+            }
+        };
+
+        handleClassChange();
+
+        return () => {
+            document.body.classList.remove("no-scrollbar");
             document.body.style.overflow = "auto";
-        }
-    }, [isLoading, mounted]);
+        };
+    }, [isLoading]);
+
 
     return (
-        <div className={styles.loading_screen}>
-            {[...Array(165)].map((_,index) => (
-                <Spinner key={index}
-                         type="grow"
-                         className={styles.spinner}
-                />
-            ))}
-        </div>
+        <>
+                <div className={styles.loading_screen}>
+                    {[...Array(spinnerCount)].map((_, index) => (
+                        <Spinner key={index} type="grow" className={styles.spinner} />
+                    ))}
+                </div>
+        </>
     );
 };

--- a/src/pages/EventEdit/EventEdit.tsx
+++ b/src/pages/EventEdit/EventEdit.tsx
@@ -157,7 +157,7 @@ export const EventEdit: React.FC = () => {
           </div>
         </div>
       ) : (
-        <LoadingScreen />
+        <LoadingScreen isLoading={isLoading}/>
       )}
     </div>
   );

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -17,6 +17,17 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+body.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+body.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+
+
 h1 {
   font-size: 44px;
   font-weight: 600;


### PR DESCRIPTION
Расширен массив до 500 элементов для поддержки высоких значений диагонали и разрешений, скрыт скроллбар при загрузке ( после загрузки overflow переходит в auto ), добавлено обязательное поле isLoading для Loading Screen.